### PR TITLE
Add ESPHome 2021.10 support for v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Copy the `idasen_desk_controller` directory into your ESPHome `custom_components
 If you use ESPHome 1.18.0 or higher you can use the external_components integration like this:
 ```
 external_components:
-  - source: github://j5lien/esphome-idasen-desk-controller@v1.2.1
+  - source: github://j5lien/esphome-idasen-desk-controller@v1.2.2
 ```
 
 For the first connection you will need to press the pairing button on the desk.
@@ -23,9 +23,16 @@ For the first connection you will need to press the pairing button on the desk.
 This component requires an [ESP32 device](https://esphome.io/devices/esp32.html).
 
 ## Configuration
-
+**NOTE: Starting with ESPHome 2021.10, additional configuration is required for the `esphome` component!**
 
 ```yaml
+esphome:
+    name: "Desk"
+    platform: esp32
+    board: esp32dev # Replace with your board
+    # Starting with ESPHome 2021.10, libraries need to be included manually
+    libraries:
+      - "ESP32 BLE Arduino" 
 idasen_desk_controller:
     # Desk controller bluetooth mac address
     # -----------

--- a/components/idasen_desk_controller/__init__.py
+++ b/components/idasen_desk_controller/__init__.py
@@ -1,10 +1,10 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import cover
-from esphome.const import ESP_PLATFORM_ESP32, CONF_ID, CONF_MAC_ADDRESS
+from esphome.const import CONF_ID, CONF_MAC_ADDRESS
 
+DEPENDENCIES = ['esp32']
 AUTO_LOAD = ['binary_sensor', 'cover', 'sensor']
-ESP_PLATFORMS = [ESP_PLATFORM_ESP32]
 MULTI_CONF = True
 
 CONF_IDASEN_DESK_CONTROLLER_ID = 'idasen_desk_controller_id'

--- a/components/idasen_desk_controller/binary_sensor.py
+++ b/components/idasen_desk_controller/binary_sensor.py
@@ -1,11 +1,11 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import binary_sensor
-from esphome.const import ESP_PLATFORM_ESP32, CONF_DEVICE_CLASS, DEVICE_CLASS_CONNECTIVITY, DEVICE_CLASS_MOVING
+from esphome.const import CONF_DEVICE_CLASS, DEVICE_CLASS_CONNECTIVITY, DEVICE_CLASS_MOVING
 from . import IdasenDeskControllerComponent, CONF_IDASEN_DESK_CONTROLLER_ID
 
-ESP_PLATFORMS = [ESP_PLATFORM_ESP32]
-DEPENDENCIES = ['idasen_desk_controller']
+
+DEPENDENCIES = ['esp32', 'idasen_desk_controller']
 
 CONF_TYPE = 'type'
 CONF_CONNECTION = 'CONNECTION'

--- a/components/idasen_desk_controller/cover.py
+++ b/components/idasen_desk_controller/cover.py
@@ -1,11 +1,9 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import cover
-from esphome.const import ESP_PLATFORM_ESP32
 from . import IdasenDeskControllerComponent, CONF_IDASEN_DESK_CONTROLLER_ID
 
-ESP_PLATFORMS = [ESP_PLATFORM_ESP32]
-DEPENDENCIES = ['idasen_desk_controller']
+DEPENDENCIES = ['esp32', 'idasen_desk_controller']
 
 CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(({
     cv.GenerateID(CONF_IDASEN_DESK_CONTROLLER_ID): cv.use_id(IdasenDeskControllerComponent),

--- a/components/idasen_desk_controller/sensor.py
+++ b/components/idasen_desk_controller/sensor.py
@@ -1,12 +1,10 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor
-from esphome.const import ESP_PLATFORM_ESP32
 from esphome.core import coroutine
 from . import IdasenDeskControllerComponent, CONF_IDASEN_DESK_CONTROLLER_ID
 
-ESP_PLATFORMS = [ESP_PLATFORM_ESP32]
-DEPENDENCIES = ['idasen_desk_controller']
+DEPENDENCIES = ['esp32', 'idasen_desk_controller']
 
 CONF_HEIGHT = 'desk_height'
 UNIT_HEIGHT = 'cm'

--- a/test.yaml
+++ b/test.yaml
@@ -3,6 +3,8 @@ esphome:
   name: test
   platform: ESP32
   board: esp32dev
+  libraries:
+    - "ESP32 BLE Arduino"
 
 wifi:
   ssid: wifi_ssid


### PR DESCRIPTION
Since ESPHome 2021.10 breaks support for libraries in external components I took the liberty to update the "legacy" version to support the new version :)