### PR TITLE
Changes via manual control are not published when bluetooth_callback=false

### DIFF
--- a/components/idasen_desk_controller/idasen_desk_controller.cpp
+++ b/components/idasen_desk_controller/idasen_desk_controller.cpp
@@ -180,6 +180,10 @@ void IdasenDeskControllerComponent::set_connection_(bool connected) {
 }
 
 void IdasenDeskControllerComponent::update_desk_data(uint8_t *pData, bool allow_publishing_cover_state) {
+  if (!this->p_client_->isConnected()) {
+    return;
+  }
+
   float height;
   float speed;
   bool callback_data = pData != nullptr;
@@ -268,13 +272,13 @@ float IdasenDeskControllerComponent::get_heigth_() {
 }
 
 void IdasenDeskControllerComponent::update_desk_() {
+  if (!this->bluetooth_callback_) { 
+    this->update_desk_data(nullptr, false);
+  }
+
   // Was stopped
   if (this->current_operation_ == cover::COVER_OPERATION_IDLE) {
     return;
-  }
-
-  if (!this->bluetooth_callback_) {
-    this->update_desk_data(nullptr, false);
   }
 
   // Retrieve current desk height


### PR DESCRIPTION
The height sensor wasn't updated when changing the height via manual controls at the desk. With this small change we keep on checking as long as we have a connection.