### PR TITLE
Added kwargs to sensor_schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .python-version
+.venv

--- a/components/idasen_desk_controller/sensor.py
+++ b/components/idasen_desk_controller/sensor.py
@@ -17,9 +17,8 @@ TYPES = {
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(CONF_IDASEN_DESK_CONTROLLER_ID): cv.use_id(IdasenDeskControllerComponent),
     cv.Optional(CONF_HEIGHT):
-        sensor.sensor_schema(UNIT_HEIGHT, ICON_HEIGHT, 0),
+        sensor.sensor_schema(unit_of_measurement=UNIT_HEIGHT, icon=ICON_HEIGHT, accuracy_decimals=0),
 })
-
 
 @coroutine
 def setup_conf(config, key, hub, func_name):


### PR DESCRIPTION
Fixes issue #45

In ESPHome 2022.3, a breaking changes introduces the use of kwargs for the `sensor_schema()` function. By specifying the parameters explicitely this PR makes the "legacy" desk component work with the change.